### PR TITLE
Minor change: Make -a option more memorable.

### DIFF
--- a/wal.edit.sh
+++ b/wal.edit.sh
@@ -539,7 +539,7 @@ Usage: wal [OPTION] -i '/path/to/dir'
 Example: wal -i '${HOME}/Pictures/Wallpapers/'
          wal -i '${HOME}/Pictures/1.jpg'
 Flags:
-  -a                      Set terminal background transparency. *Only works in URxvt*
+  -a                      Set terminal background alpha channel (vulgo transparency). *Only works in URxvt*
   -c                      Delete all cached colorschemes.
   -h                      Display this help page.
   -i '/path/to/dir'       Which image to use.


### PR DESCRIPTION
Transparency and -a don't memorize well together. Therefore I recommend to mention the fact that you are altering the alpha channel.